### PR TITLE
Add CLI pipeline and workflow docs

### DIFF
--- a/PROJECT_FLOW.md
+++ b/PROJECT_FLOW.md
@@ -1,0 +1,21 @@
+# RAG-Driven Project Flow
+
+This document outlines how to use the repository's tools to handle different project scenarios with Retrieval Augmented Generation (RAG) and specialized AI agents.
+
+## 1. Generate a New Project
+1. **Prepare Requirement Documents** – gather specs or write a prompt.
+2. **Index with RAG** – upload the docs so the `ProjectRAG` system can create semantic embeddings.
+3. **Run the Project Generator** – choose the `project generator` agent. It will read the RAG context and produce full source code, documentation and setup instructions.
+4. **Download the Result** – the `ProjectOrchestrator` can export everything as a ZIP archive.
+
+## 2. Analyse an Existing Project
+1. **Upload Project Files or a Repository URL** – the files are indexed with RAG for contextual search.
+2. **Select the `project analyzer` Agent** – it uses the indexed context to create onboarding documents describing architecture, technologies and setup steps.
+3. **Share the Generated Report** – new team members can read the summary to understand the project quickly.
+
+## 3. Extend an Existing Project
+1. **Upload the Current Code Base** – index it with `ProjectRAG`.
+2. **Select the `code assistant` Agent** – provide a prompt describing the new feature or modification.
+3. **Receive Updated Source Code** – the agent generates new or modified files following the original project style.
+
+These flows are also available via the Streamlit interface in `app_final.py` or through the CLI utility described below.

--- a/README.md
+++ b/README.md
@@ -128,6 +128,24 @@ GITHUB_TOKEN=your-github-token
 ```bash
 streamlit run app_final.py
 ```
+### 6. Command-Line Workflow
+Use `agent_pipeline.py` for quick experiments without the web UI.
+
+Generate a project from docs:
+```bash
+python agent_pipeline.py generator --docs path/to/docs --project MyApp
+```
+
+Analyse an existing project:
+```bash
+python agent_pipeline.py analyzer path/to/project
+```
+
+Extend a project with new code:
+```bash
+python agent_pipeline.py coder path/to/project "add login feature"
+
+```
 
 ## 📖 Usage Guide
 

--- a/agent_pipeline.py
+++ b/agent_pipeline.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Simple command-line interface for RAG powered project flows.
+
+This utility lets you run the main workflows without the Streamlit UI:
+
+- ``generator`` – create a full project from requirement documents or a text prompt.
+- ``analyzer`` – summarise an existing project for onboarding.
+- ``coder`` – generate new code for an existing project.
+"""
+
+import argparse
+import json
+import os
+import zipfile
+from typing import Dict
+
+from rag_system import ProjectRAG
+from project_orchestrator import create_project_orchestrator, GenerationOptions
+from model_adapter import ModelClient
+
+
+def load_files(path: str) -> Dict[str, str]:
+    """Load text files from a directory or zip archive."""
+    files: Dict[str, str] = {}
+    if os.path.isdir(path):
+        for root, _, filenames in os.walk(path):
+            for fname in filenames:
+                fpath = os.path.join(root, fname)
+                try:
+                    with open(fpath, "r", encoding="utf-8", errors="ignore") as f:
+                        rel = os.path.relpath(fpath, path)
+                        files[rel] = f.read()
+                except Exception:
+                    continue
+    elif zipfile.is_zipfile(path):
+        with zipfile.ZipFile(path, "r") as zf:
+            for name in zf.namelist():
+                if name.endswith("/"):
+                    continue
+                try:
+                    with zf.open(name) as f:
+                        files[name] = f.read().decode("utf-8", errors="ignore")
+                except Exception:
+                    continue
+    else:
+        with open(path, "r", encoding="utf-8", errors="ignore") as f:
+            files[os.path.basename(path)] = f.read()
+    return files
+
+
+def run_generator(docs: str | None, prompt: str | None, project: str) -> None:
+    orchestrator = create_project_orchestrator()
+    options = GenerationOptions()
+    if docs:
+        documents = load_files(docs)
+        result = orchestrator.generate_project_from_documents(documents, project, options)
+    else:
+        result = orchestrator.generate_project_from_prompt(prompt or "", project, options)
+    archive = orchestrator.export_project_as_zip(result)
+    out = f"{project or 'generated_project'}.zip"
+    with open(out, "wb") as f:
+        f.write(archive)
+    print(f"\n✅ Project archive saved to {out}")
+    print(result.summary)
+
+
+def run_analyzer(project_path: str) -> None:
+    files = load_files(project_path)
+    rag = ProjectRAG()
+    rag.index_project_files(files)
+    summary = rag.generate_project_summary("default", "current")
+    prompt = (
+        "You are a senior developer. Provide a concise onboarding document for "
+        "the following project summary:\n" + json.dumps(summary, indent=2)
+    )
+    model = ModelClient()
+    analysis = model.generate_response(prompt)
+    print("\n=== Project Analysis ===\n")
+    print(analysis)
+
+
+def run_coder(project_path: str, prompt: str) -> None:
+    files = load_files(project_path)
+    rag = ProjectRAG()
+    rag.index_project_files(files)
+    context = rag.get_relevant_context("default", "current", prompt, max_chunks=3)
+    context_text = "\n\n".join(c.chunk.content for c in context)
+    full_prompt = (
+        f"Existing project context:\n{context_text}\n\nGenerate code for: {prompt}"
+    )
+    model = ModelClient()
+    response = model.generate_response(full_prompt)
+    print("\n=== Generated Code ===\n")
+    print(response)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run RAG project flows")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    gen = sub.add_parser("generator", help="Generate a new project")
+    gen.add_argument("--docs", help="Path to requirements docs or zip")
+    gen.add_argument("--prompt", help="Text prompt for the project")
+    gen.add_argument("--project", default="generated_project", help="Output project name")
+
+    ana = sub.add_parser("analyzer", help="Analyse an existing project")
+    ana.add_argument("project", help="Path to project directory or zip")
+
+    cod = sub.add_parser("coder", help="Generate code for an existing project")
+    cod.add_argument("project", help="Path to project directory or zip")
+    cod.add_argument("prompt", help="Feature description")
+
+    args = parser.parse_args()
+
+    if args.command == "generator":
+        run_generator(args.docs, args.prompt, args.project)
+    elif args.command == "analyzer":
+        run_analyzer(args.project)
+    elif args.command == "coder":
+        run_coder(args.project, args.prompt)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- document RAG-based project flows
- add `agent_pipeline.py` CLI to run generator/analyzer/coder without the UI
- mention the new CLI in README

## Testing
- `python -m py_compile agent_pipeline.py project_generator.py project_orchestrator.py rag_system.py model_adapter.py openai_utils.py gemini_utils.py git_repository_integration.py code_validator.py app_final.py launch.py`
- `python -m py_compile agent_pipeline.py`

------
https://chatgpt.com/codex/tasks/task_e_687289b074548321aafe1578a7fcd28a