### PR TITLE
Align docs with three-agent model

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,10 @@ A comprehensive AI-powered development environment that combines multi-model cha
 ### 📊 **Intelligent Project Analysis**
 - **Basic Analysis**: Works with Gemini for immediate insights
 - **Advanced RAG System**: Semantic search across codebases (optional)
-- **AI Agent Orchestra**: 7 specialized analysis agents
+ - **AI Agent Orchestra**: 3 specialized agents
+  - 🚀 Project Generator - Create complete projects from docs or prompts
   - 🔍 Project Analyzer - Architecture and structure analysis
-  - 👨‍💻 Code Reviewer - Quality and best practices audit
-  - 📚 Documentation Generator - Auto-generate comprehensive docs
-  - 🛡️ Security Auditor - Vulnerability and security analysis
-  - 🏗️ Architecture Analyst - Design patterns and structure review
-  - 📦 Dependency Manager - Package and dependency analysis
-  - 🧪 Test Generator - Test case and coverage suggestions
+  - 🛠️ Code Assistant - Extend existing projects with new features
 
 ### 🚀 **Full Project Generator** ⭐ NEW!
 - **Complete Project Creation**: Generate entire projects from descriptions or documentation
@@ -263,7 +259,7 @@ python agent_pipeline.py coder path/to/project "add login feature"
 
 ### Adding New Features
 - **New AI Models**: Add to model utilities and update model_adapter.py
-- **New Agents**: Extend ai_agents.py with new specialized agents
+ - **New Agents**: Customize `generate_agent_response` in `app_final.py` to add new specialized agents
 - **New Platforms**: Add to git_repository_integration.py
 
 ## 📄 License

--- a/app_final.py
+++ b/app_final.py
@@ -980,7 +980,7 @@ def chat_ui():
             "gpt-3.5-turbo": "GPT-3.5 Turbo"
         }
         selected_model = st.session_state.get("selected_model", "gemini-2.5-pro")
-        selected_agent = st.session_state.get("selected_agent", "💬 General Assistant")
+        selected_agent = st.session_state.get("selected_agent", "🚀 Project Generator")
         model_display = model_dict.get(selected_model, selected_model)
         st.markdown(f"<div style='background:#f5f6fa;padding:10px 16px;border-radius:8px;margin-bottom:8px;'><b>Model:</b> {model_display} &nbsp; | &nbsp; <b>Agent:</b> {selected_agent}</div>", unsafe_allow_html=True)
 


### PR DESCRIPTION
## Summary
- update README to document only 3 agents
- note how to extend agents via `app_final.py`
- default UI agent is now Project Generator

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875579881a08321963f3f4e6a7ae821